### PR TITLE
Fix: default config directory should be consistent to $HOME/.config

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Once that's done you're all ready. Just `cd` into your project
 directory and run `autosaved watch`, this will notify the daemon to start
 watching the directory.
 
-It does so by adding the repository's full path to the configuration (by default ~/.autosaved.yaml), which gets picked up by
+It does so by adding the repository's full path to the configuration (by default `~/.config/.autosaved.yaml` or under the path define by environment variable `XDG_CONFIG_HOME`), which gets picked up by
 Viper on the fly.
 
 #### Systemd

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -75,7 +75,7 @@ func init() {
 	rootCmd.AddCommand(restoreCmd)
 }
 
-// get one of available config path from environment variable, $HOME/.config, $HOME
+// get one of available config path from environment variable XDG_CONFIG_HOME or default path $HOME/.config
 func getConfigHomePath() string {
 	if xdgHome := os.Getenv("XDG_CONFIG_HOME"); xdgHome != "" {
 		return xdgHome
@@ -85,14 +85,12 @@ func getConfigHomePath() string {
 	cobra.CheckErr(err)
 
 	// default XDG_CONFIG_HOME "$HOME/.config"
+	// create if not exist
 	configHome := filepath.Join(userHome, ".config")
-	// check directory exist
-	if _, err := os.Stat(configHome); err == nil {
-		return configHome
-	}
+	err = os.MkdirAll(configHome, os.ModePerm)
+	cobra.CheckErr(err)
 
-	// default path: user's home
-	return userHome
+	return configHome
 }
 
 // compatible previous version


### PR DESCRIPTION
Default dirctory might be $HOME/.config or $HOME/ if first one is not exist, that might
caused confusion for users.